### PR TITLE
changed the initial value of fullmove: 0 => 1

### DIFF
--- a/lib/pgn/position.rb
+++ b/lib/pgn/position.rb
@@ -61,7 +61,7 @@ module PGN
     #     :white,
     #   )
     #
-    def initialize(board, player, castling = CASTLING, en_passant = nil, halfmove = 0, fullmove = 0)
+    def initialize(board, player, castling = CASTLING, en_passant = nil, halfmove = 0, fullmove = 1)
       self.board      = board
       self.player     = player
       self.castling   = castling

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -9,5 +9,13 @@ describe PGN::Game do
       game = PGN::Game.new(moves, tags, result)
       lambda { game.positions }.should_not raise_error
     end
+
+    it "should have fullmove 2 after 1.e4 c5" do
+      moves = %w{e4 c5}
+      game = PGN::Game.new(moves)
+      last_pos = game.positions.last
+
+      last_pos.fullmove.should == 2
+    end
   end
 end

--- a/spec/position_spec.rb
+++ b/spec/position_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe PGN::Position do
+
+  describe "start" do
+
+    it "should have fullmove 1" do
+      pos = PGN::Position.start
+      pos.fullmove.should == 1
+    end
+    
+  end
+  
   context "disambiguating moves" do
     describe "using SAN square disambiguation" do
       pos = PGN::FEN.new("r1bqkb1r/pp1p1ppp/2n1pn2/8/3NP3/2N5/PPP2PPP/R1BQKB1R w KQkq - 3 6").to_position


### PR DESCRIPTION
Hi,

This pull request changes just one thing:
 - The initial value of fullmove is 1 instead of 0.  
This complies with the FEN-specification.  
(http://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)
 -  added 2 specs to verify this new behaviour.

The older specs are unchanged and still green.

If you agree with this change, please merge this pull request, and perhaps release a new version.
Let me know, if you have any questions or if I need to do sth else to get this pull request merged.
Anyway, thanks for this cool gem.

Cheers,
r11runner