### PR TITLE
restrict castling if rooks are captured

### DIFF
--- a/lib/pgn/move_calculator.rb
+++ b/lib/pgn/move_calculator.rb
@@ -116,6 +116,11 @@ module PGN
 
       restrict = "KQ" if ['K', 'Q'].include? move.castle
       restrict = "kq" if ['k', 'q'].include? move.castle
+      
+      restrict += 'Q' if self.move.destination == 'a1' && !restrict.include?('Q')
+      restrict += 'q' if self.move.destination == 'a8' && !restrict.include?('q')
+      restrict += 'K' if self.move.destination == 'h1' && !restrict.include?('K')
+      restrict += 'k' if self.move.destination == 'h8' && !restrict.include?('k')
 
       restrict ||= ''
 


### PR DESCRIPTION
The castling flags in the fen_list still have castling options when rooks are captured. Added code to restrict those castling if the a1, a8, h1, h8 squares are destinations for a piece.