### PR TITLE
Preserve FEN#en_passant when converting to Position

### DIFF
--- a/lib/pgn/fen.rb
+++ b/lib/pgn/fen.rb
@@ -114,7 +114,7 @@ module PGN
     def to_position
       player     = self.active == 'w' ? :white : :black
       castling   = self.castling.split('') - ['-']
-      en_passant = self.en_passant == '-' ? nil : en_passant
+      en_passant = self.en_passant == '-' ? nil : self.en_passant
 
       PGN::Position.new(
         self.board,

--- a/spec/fen_spec.rb
+++ b/spec/fen_spec.rb
@@ -47,6 +47,11 @@ describe PGN::FEN do
       next_pos = pos.move("d6")
       next_pos.to_fen.en_passant.should == "-"
     end
+
+    it "should preserve the en_passant square when round-tripping through a position" do
+      pos = PGN::FEN.new("1r6/4k3/5p1p/2PB4/pP4P1/P1K4P/8/8 b - b3 0 1").to_position
+      pos.to_fen.en_passant.should == 'b3'
+    end
   end
 
   describe "halfmove counter" do


### PR DESCRIPTION
When converting a FEN's en-passant square to the Position format, the autovivified `en_passant` variable is accidentally used later in the statement instead of the `en_passant` *accessor* as one would expect.

```ruby
en_passant = self.en_passant == '-' ? nil : en_passant
^ variable        ^ accessor                ^ variable!
```